### PR TITLE
Allow proper privatization of internal attributes

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/attr_internal.rb
+++ b/activesupport/lib/active_support/core_ext/module/attr_internal.rb
@@ -3,19 +3,21 @@
 class Module
   # Declares an attribute reader backed by an internally-named instance variable.
   def attr_internal_reader(*attrs)
-    attrs.each { |attr_name| attr_internal_define(attr_name, :reader) }
+    attrs.map { |attr_name| attr_internal_define(attr_name, :reader) }
   end
 
   # Declares an attribute writer backed by an internally-named instance variable.
   def attr_internal_writer(*attrs)
-    attrs.each { |attr_name| attr_internal_define(attr_name, :writer) }
+    attrs.map { |attr_name| attr_internal_define(attr_name, :writer) }
   end
 
   # Declares an attribute reader and writer backed by an internally-named instance
   # variable.
   def attr_internal_accessor(*attrs)
-    attr_internal_reader(*attrs)
-    attr_internal_writer(*attrs)
+    [
+      attr_internal_reader(*attrs),
+      attr_internal_writer(*attrs)
+    ].flatten
   end
   alias_method :attr_internal, :attr_internal_accessor
 
@@ -34,5 +36,6 @@ class Module
       attr_name, internal_name = "#{attr_name}=", "#{internal_name}=" if type == :writer
       alias_method attr_name, internal_name
       remove_method internal_name
+      attr_name
     end
 end


### PR DESCRIPTION
### Summary

This change allows:

```rb
class Foo
  private *(attr_internal :bar, :baz)
end
```

The motivation is to allow encapsulating instance variables (for the sake of future extensibility) without polluting the interface with methods that are for internal use.
